### PR TITLE
Fix typo in setData.json

### DIFF
--- a/public/javascripts/setData.json
+++ b/public/javascripts/setData.json
@@ -661,7 +661,7 @@
          "fruit of our labors",
          "\"spoooooooky!\""
       ],
-      "UltraRares":[
+      "Ultrarares":[
          "airstream driver",
          "howitzer impact cyclone",
          "electromagnetic stomp",

--- a/public/javascripts/setData.json
+++ b/public/javascripts/setData.json
@@ -678,7 +678,7 @@
          "excited for blood",
          "aiming for #1"
       ],
-      "SecretRares":[
+      "Secretrares":[
          "dropkick slicer",
          "joint effort offensive"
       ],


### PR DESCRIPTION
Fixes #2 
Site was erroring out when trying to load URs from set 2 because the array in setData.json was named "UltraRares" instead of "Ultrarares".